### PR TITLE
Update lambda_function.py

### DIFF
--- a/slack-version/lambda_function.py
+++ b/slack-version/lambda_function.py
@@ -205,30 +205,33 @@ def lambda_handler(event, context):
             else:
                 strEndTime = "None given"
             
-            if diff_dates(strUpdate, now) < int(intHours):
-                try:
-                    response = HealthIssuesTable.get_item(
-                        Key = {
-                            'arn' : strArn
-                        }
-                )
-                except ClientError as e:
-                    print(e.response['Error']['Message'])
-                else:
-                    isItemResponse = response.get('Item')
-                    if isItemResponse == None:
-                        print (datetime.now().strftime(strDTMFormat2)+": record not found")
-                        update_ddb(HealthIssuesTable, strArn, strUpdate, now, intHours)
-                        affectedAccounts = get_healthAccounts (awshealth, event, strArn, awsRegion)
-                        healthUpdates = get_healthUpdates(awshealth, event, strArn, awsRegion, affectedAccounts)
-                        affectedEntities = get_healthEntities(awshealth, event, strArn, awsRegion, affectedAccounts)
-                        send_webhook(datetime.now().strftime(strDTMFormat2), strStartTime, strEndTime, event, awsRegion, decodedWebHook, healthUpdates, affectedAccounts, affectedEntities)
-                    else:
-                        item = response['Item']
-                        if item['lastUpdatedTime'] != strUpdate:
-                          print (datetime.now().strftime(strDTMFormat2)+": last Update is different")
-                          update_ddb(HealthIssuesTable, strArn, strUpdate, now, intHours)
-                          affectedAccounts = get_healthAccounts (awshealth, event, strArn, awsRegion)                      
-                          healthUpdates = get_healthUpdates(awshealth, event, strArn, awsRegion, affectedAccounts)
-                          affectedEntities = get_healthEntities(awshealth, event, strArn, awsRegion, affectedAccounts)
-                          send_webhook(datetime.now().strftime(strDTMFormat2), strStartTime, strEndTime, event, awsRegion, decodedWebHook, healthUpdates, affectedAccounts, affectedEntities)
+#            if diff_dates(strUpdate, now) < int(intHours):
+            try:
+                response = HealthIssuesTable.get_item(
+                    Key = {
+                        'arn' : strArn
+                    }
+            )
+            except ClientError as e:
+                print(e.response['Error']['Message'])
+            #else:
+            try:
+                isItemResponse = response.get('Item')
+            except:
+                pass
+            if isItemResponse == None:
+                print (datetime.now().strftime(strDTMFormat2)+": record not found")
+                update_ddb(HealthIssuesTable, strArn, strUpdate, now, intHours)
+                affectedAccounts = get_healthAccounts (awshealth, event, strArn, awsRegion)
+                healthUpdates = get_healthUpdates(awshealth, event, strArn, awsRegion, affectedAccounts)
+                affectedEntities = get_healthEntities(awshealth, event, strArn, awsRegion, affectedAccounts)
+                send_webhook(datetime.now().strftime(strDTMFormat2), strStartTime, strEndTime, event, awsRegion, decodedWebHook, healthUpdates, affectedAccounts, affectedEntities)
+            else:
+                item = response['Item']
+                if item['lastUpdatedTime'] != strUpdate:
+                  print (datetime.now().strftime(strDTMFormat2)+": last Update is different")
+                  update_ddb(HealthIssuesTable, strArn, strUpdate, now, intHours)
+                  affectedAccounts = get_healthAccounts (awshealth, event, strArn, awsRegion)                      
+                  healthUpdates = get_healthUpdates(awshealth, event, strArn, awsRegion, affectedAccounts)
+                  affectedEntities = get_healthEntities(awshealth, event, strArn, awsRegion, affectedAccounts)
+                  send_webhook(datetime.now().strftime(strDTMFormat2), strStartTime, strEndTime, event, awsRegion, decodedWebHook, healthUpdates, affectedAccounts, affectedEntities)

--- a/slack-version/lambda_function.py
+++ b/slack-version/lambda_function.py
@@ -235,3 +235,6 @@ def lambda_handler(event, context):
                   healthUpdates = get_healthUpdates(awshealth, event, strArn, awsRegion, affectedAccounts)
                   affectedEntities = get_healthEntities(awshealth, event, strArn, awsRegion, affectedAccounts)
                   send_webhook(datetime.now().strftime(strDTMFormat2), strStartTime, strEndTime, event, awsRegion, decodedWebHook, healthUpdates, affectedAccounts, affectedEntities)
+                else:
+                    print(strArn)
+                    print("Skipped duplicate record")


### PR DESCRIPTION
if diff_dates(strUpdate, now) < int(intHours):

This line breaks things, as intHours is in seconds and strUpdate and now are both in epoch time. Even if intHours was in the correct format all this does is make old alerts occur if they're over 24 hours old.

You need a try statement around isItemResponse = response.get('Item'), as if the item isn't in the database it'll throw an error because response.get is invalid for NoneType.

I also fixed an indent error for the last else statement.

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
